### PR TITLE
added `giddyup ip myip` to get the managed-ip of the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Current capabilities:
  * Proxy traffic to the leader
  * Wait for service to have the desired scale.
  * Get the scale of the service
+ * Get Managed-IP of the container (/self/container/primary_ip)
 
 ## Versions
 
@@ -55,7 +56,9 @@ connection_string=$(./giddyup ip stringify --suffix :2181 zookeeper/zookeeper)
 
 ## Usage
 
-### ip stringify
+### IP
+
+#### stringify
 ```
 NAME:
    giddyup ip stringify - Prints a joined list of IPs
@@ -70,6 +73,16 @@ OPTIONS:
    --source "metadata"	Source to lookup IPs. [metadata, dns]
    --use-agent-ips	Use agent ips instead of rancher ips, only works with metadata source
    --use-agent-names	Use agent name instead of rancher ips, only works with metadata source
+```
+
+#### myip
+```
+NAME:
+   giddyup ip myip - Prints the IP of the container
+
+USAGE:
+   giddyup ip myip
+
 ```
 
 ### leader

--- a/app/ip.go
+++ b/app/ip.go
@@ -58,9 +58,23 @@ func IPCommand() cli.Command {
 						Usage: "Use agent name instead of rancher ips, only works with metadata source",
 					},
 				},
+			},{
+				Name:  "myip",
+				Usage: "Prints the containers Rancher managed IP",
+				Action: ipMyIpAction,
 			},
 		},
 	}
+}
+
+func ipMyIpAction(c *cli.Context) {
+	mdClient, _ := metadata.NewClientAndWait(metadataURL)
+
+	selfContainer, err := mdClient.GetSelfContainer()
+	if err != nil {
+		logrus.Fatalf("Failed to find IP: %v", err)
+	}
+	fmt.Print(selfContainer.PrimaryIp)
 }
 
 func ipStringifyAction(c *cli.Context) {


### PR DESCRIPTION
This PR adds commain `giddyup ip myip` to fetch the managed-IP of the container on which the app is running. It uses `/self/container/primary_ip`.